### PR TITLE
Normalize the path of the file directory

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -35,7 +35,7 @@ get <- function(value = NULL,
       file <- normalizePath(file, mustWork = FALSE)
 
       # check if we are at the end of the search
-      file_dir <- dirname(file)
+      file_dir <- normalizePath(dirname(file))
       parent_dir <- dirname(file_dir)
       if (file_dir == parent_dir)
         break

--- a/tests/testthat/test-parent.R
+++ b/tests/testthat/test-parent.R
@@ -18,4 +18,9 @@ test_that("search for config file properly terminates", {
                regexp = "not found in current working")
 })
 
-
+test_that("search for config file works without directory", {
+  old <- setwd("parent")
+  on.exit(setwd(old))
+  expect_identical(config::get("color", file = "config-multiple.yml"),
+                   "red")
+})


### PR DESCRIPTION
Otherwise `dirname(file)` always returns `.`, unless a full directory
path is given to `get()`.

Fixes #5