### PR TITLE
default config-file can be configured via environment variable

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -24,7 +24,7 @@
 #' @export
 get <- function(value = NULL,
                 config = Sys.getenv("R_CONFIG_ACTIVE", "default"),
-                file = "config.yml",
+                file = Sys.getenv("R_CONFIG_FILE", "config.yml"),
                 use_parent = TRUE) {
 
   # find the file (scan parent directories above if need be)


### PR DESCRIPTION
Hi,

thanks for this great R-package.

The default config file in `get` is `config.yaml` which is unfortunately not compatible with my teams guidelines. So I thought it might be a good idea to have the possibility to set it via an environment variable?

BR Frank