### PR TITLE
Evaluate expressions in yaml without using handler function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
   person("JJ", "Allaire", role = c("aut", "cre"), email = "jj@rstudio.com"),
   person(family = "RStudio, Inc.", role = "cph"))
 Imports:
-    yaml (>= 2.1.13)
+    yaml (>= 2.1.19)
 Suggests:
     testthat,
     knitr

--- a/R/get.R
+++ b/R/get.R
@@ -53,7 +53,7 @@ get <- function(value = NULL,
 
   # load the yaml
   config_yaml <- yaml::yaml.load_file(
-    file, handlers = list(expr = function(x) eval(parse(text = x)))
+    file, eval.expr = TRUE
   )
 
   # get the default config (required)


### PR DESCRIPTION
A more elegant way to resolve https://github.com/rstudio/config/issues/12 is now available, by using `yaml.load_file()` with `eval.expr = TRUE`.