### PR TITLE
Eval only after the configuration was merged.  Possible fix for #20

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -89,10 +89,7 @@ get <- function(value = NULL,
 
   # check whether any expressions need to be evaluated
   is_expr <- vapply(active_config, is.expression, logical(1))
-  if (any(is_expr)) {
-    active_config[is_expr] <- lapply(active_config[is_expr], eval, envir = baseenv())
-  }
-
+  active_config[is_expr] <- lapply(active_config[is_expr], eval, envir = baseenv())
 
   # return either the entire config or a requested value
   if (!is.null(value))

--- a/R/get.R
+++ b/R/get.R
@@ -87,9 +87,19 @@ get <- function(value = NULL,
   # merge the specified configuration with the default configuration
   active_config <- merge_lists(default_config, do_get(config))
 
-  # check whether any expressions need to be evaluated
-  is_expr <- vapply(active_config, is.expression, logical(1))
-  active_config[is_expr] <- lapply(active_config[is_expr], eval, envir = baseenv())
+  # check whether any expressions need to be evaluated recursively
+
+  eval_recursively <- function(x){
+    is_expr <- vapply(x, is.expression, logical(1))
+    x[is_expr] <- lapply(x[is_expr], eval, envir = baseenv())
+
+    is_list <- vapply(x, is.list, logical(1))
+    x[is_list] <- lapply(x[is_list], eval_recursively)
+
+    x
+  }
+
+  active_config <- eval_recursively(active_config)
 
   # return either the entire config or a requested value
   if (!is.null(value))

--- a/tests/testthat/config.yml
+++ b/tests/testthat/config.yml
@@ -16,3 +16,5 @@ production:
 dynamic:
   color: !expr paste("orange")
 
+error:
+  color: !expr stop("this should not be evaluated")

--- a/tests/testthat/config.yml
+++ b/tests/testthat/config.yml
@@ -15,6 +15,9 @@ production:
 
 dynamic:
   color: !expr paste("orange")
+  nested:
+    shape: !expr paste("circle")
+    taste: !expr paste("sweet")
 
 error:
   color: !expr stop("this should not be evaluated")

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -46,3 +46,10 @@ test_that("R code is executed when reading configurations", {
   expect_error(config::get("color", config = "error"))
 })
 
+test_that("expressions are evaluated recursively", {
+  expect_identical(
+    config::get("nested", config = "dynamic"),
+    list(shape = "circle", taste = "sweet")
+  )
+})
+

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -43,5 +43,6 @@ test_that("active configuration can be changed via an environment variable", {
 
 test_that("R code is executed when reading configurations", {
   expect_identical(config::get("color", config = "dynamic"), "orange")
+  expect_error(config::get("color", config = "error"))
 })
 


### PR DESCRIPTION
At the moment, all `!expr` statements in the config file are evaluated, even if these are not relevant for the active configuration.   This PR proposes a fix to read the yaml file with `eval.expr = FALSE` (using a handler) and then evaluates these statements only after the merge is completed.  I also add additional test cases (that fail with current code base, but passes with the proposed fix).

This is hopefully a fix for #20 