### PR TITLE
eval expressions in parent environment

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -98,7 +98,7 @@ get <- function(value = NULL,
 
   eval_recursively <- function(x){
     is_expr <- vapply(x, is.expression, logical(1))
-    x[is_expr] <- lapply(x[is_expr], eval, envir = baseenv())
+    x[is_expr] <- lapply(x[is_expr], eval, envir = parent.frame(n = 2))
 
     is_list <- vapply(x, is.list, logical(1))
     x[is_list] <- lapply(x[is_list], eval_recursively)

--- a/tests/testthat/config.yml
+++ b/tests/testthat/config.yml
@@ -21,3 +21,6 @@ dynamic:
 
 error:
   color: !expr stop("this should not be evaluated")
+
+parentenv:
+  color: !expr paste(use_color)

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -44,6 +44,10 @@ test_that("active configuration can be changed via an environment variable", {
 test_that("R code is executed when reading configurations", {
   expect_identical(config::get("color", config = "dynamic"), "orange")
   expect_error(config::get("color", config = "error"))
+
+  use_color <- "orange"
+  get_color <- config::get("color", config = "parentenv")
+  expect_identical(get_color, use_color)
 })
 
 test_that("expressions are evaluated recursively", {


### PR DESCRIPTION
Hi config maintainers.

Before #29, I think R expressions were evaluated in the environment that called `config::get` rather than the `base_env`. I was using this functionality to base config variables off of 
1. command line arguments
2. create somewhat verbose new arguments based off of previously loaded config files (`!expr server` vs `!expr config::get("server", file = "/etc/server-config.yml")`

Some of my current config workflows were broken after #29, I think this also related to this [comment](https://github.com/rstudio/config/issues/20#issuecomment-762733391) on #20.

Was changing to evaluating expressions in the `base_env()` an intended change? Please let me know if I should make any changes to this PR. Thanks for your work on this helpful package!